### PR TITLE
fix(spec): reject a rule marked inside an informative section

### DIFF
--- a/scripts/extract_rules.py
+++ b/scripts/extract_rules.py
@@ -40,6 +40,7 @@ from rule_ids import AREAS, LEGACY_ID, PLACEHOLDER  # noqa: E402
 from rule_ids import MARKER as RULE  # noqa: E402
 from rule_ids import RULE_ID  # noqa: E402
 from rule_scope import sentence_end  # noqa: E402
+from section_scope import informative_lines  # noqa: E402
 
 #: Who a requirement binds. This decides what is able to enforce it: `document` rules are
 #: machine-checkable by validating a schema or instance, `implementation` rules constrain a
@@ -348,6 +349,7 @@ def extract_file(filename: str, problems: list[str], notes: list[str]) -> list[d
     rules: list[dict] = []
     section = None
     informative = non_normative_blocks(lines)
+    informative_sections = informative_lines(lines)
     for number, line in enumerate(lines):
         heading = HEADING.match(line)
         if heading:
@@ -361,6 +363,19 @@ def extract_file(filename: str, problems: list[str], notes: list[str]) -> list[d
                     f"{where}: {rule_id} is inside a :::note/:::example block, which the "
                     "conformance section declares non-normative. Move the requirement into "
                     "normative prose, or set in_note=yes if the placement is deliberate."
+                )
+                continue
+
+            # The other half of "non-normative": a section marked `.informative`. Unlike a note,
+            # there is no in_note-style escape, because the section heading already says the whole
+            # section is disclaimed - a rule there would have the catalogue assert a requirement
+            # the specification withdraws on the same page. Move the section or move the rule.
+            if number in informative_sections:
+                problems.append(
+                    f"{where}: {rule_id} is inside a section marked .informative, which the "
+                    "conformance section declares non-normative, so the catalog would state a "
+                    "requirement the specification does not. Move the requirement into a "
+                    "normative section."
                 )
                 continue
 

--- a/scripts/render_spec.py
+++ b/scripts/render_spec.py
@@ -34,6 +34,7 @@ import macros  # noqa: E402  - repo-root shared macros
 import spec_config as cfg  # noqa: E402
 from rule_ids import MARKER as RULE  # noqa: E402
 from rule_scope import sentence_end  # noqa: E402
+from section_scope import is_informative  # noqa: E402
 
 SECTIONS_DIR = os.path.join(ROOT, "spec", "sections")
 OUT = os.path.join(ROOT, "docs", "spec", "index.html")
@@ -245,7 +246,7 @@ def parse_sections(text):
 
 
 def render_node(node, informative):
-    informative = informative or ("informative" in node["classes"]) or node["id"] in ("index", "introduction")
+    informative = is_informative(node["id"], node["classes"], informative)
     attrs = f' id="{node["id"]}"' if node["id"] else ""
     if node["classes"]:
         attrs += f' class="{" ".join(node["classes"])}"'

--- a/scripts/section_scope.py
+++ b/scripts/section_scope.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""Which parts of a section file are non-normative, shared by rendering and extraction.
+
+The conformance section declares that "as well as sections marked as non-normative, all authoring
+guidelines, diagrams, examples, and notes in this specification are non-normative". Two mechanisms
+express that: the `:::note` / `:::example` blocks that `extract_rules.non_normative_blocks` already
+handles, and a heading marked `.informative`, which is what this module covers.
+
+`scripts/render_spec.py` acted on the second and `scripts/extract_rules.py` did not, so a
+`:rule[...]` placed in an informative section was rendered without RFC 2119 markup and catalogued
+as normative anyway - the catalogue asserting a requirement the specification disclaims on the same
+page. Nothing exploited that, but only because no marker had been written there yet.
+
+The rule itself is small and lives in :func:`is_informative`, so the renderer and the extractor
+cannot disagree about it. Its inheritance is the part worth stating: `informative` propagates to
+every descendant heading, so marking a level-4 section covers the level-5 sections beneath it.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: An ATX heading, level 2 to 6. Level 1 is the document title and carries no section.
+HEADING = re.compile(r"^(#{2,6})\s+(.*?)\s*$")
+
+#: The trailing `{#id .class}` attribute block on a heading.
+ATTRS = re.compile(r"\s*\{([^}]*)\}\s*$")
+
+#: Section ids that are non-normative whatever they declare, because what they are is structural
+#: rather than a choice: the generated index, and the introduction.
+ALWAYS_INFORMATIVE = ("index", "introduction")
+
+
+def parse_heading(line: str) -> tuple[int, str | None, list[str]] | None:
+    """`(level, id, classes)` for a heading line, or None if the line is not one."""
+    match = HEADING.match(line)
+    if not match:
+        return None
+    level, title = len(match.group(1)), match.group(2)
+    node_id, classes = None, []
+    attrs = ATTRS.search(title)
+    if attrs:
+        for token in attrs.group(1).split():
+            if token.startswith("#"):
+                node_id = token[1:]
+            elif token.startswith("."):
+                classes.append(token[1:])
+    return level, node_id, classes
+
+
+def is_informative(node_id: str | None, classes: list[str], parent_informative: bool) -> bool:
+    """Whether a section is non-normative, given its own markers and its parent's state."""
+    return parent_informative or "informative" in classes or node_id in ALWAYS_INFORMATIVE
+
+
+def informative_lines(lines: list[str]) -> set[int]:
+    """Indices of the lines of one section file that sit inside an informative section.
+
+    The heading itself is included, so a marker written on the heading line is caught too.
+    """
+    inside: set[int] = set()
+    #: (level, informative) for each open ancestor, so the flag can be inherited and then
+    #: dropped again when a sibling at the same level starts.
+    stack: list[tuple[int, bool]] = []
+    for number, line in enumerate(lines):
+        heading = parse_heading(line)
+        if heading:
+            level, node_id, classes = heading
+            while stack and stack[-1][0] >= level:
+                stack.pop()
+            informative = is_informative(node_id, classes, stack[-1][1] if stack else False)
+            stack.append((level, informative))
+        if stack and stack[-1][1]:
+            inside.add(number)
+    return inside


### PR DESCRIPTION
`extract_rules.py` guarded `:::note` and `:::example` blocks but not headings marked `.informative`. Both are non-normative by the same sentence in `03-conformance.md`:

> As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative.

So a `:rule[...]` written in an informative section was rendered **without** RFC 2119 markup, because `render_spec.py` skips it there, and catalogued as a normative requirement anyway. The catalogue would assert a requirement the specification withdraws on the same page.

Nothing exploits this today - no marker sits in an informative section - but the reverse case has now happened three times: `OOLD-SCH-2d05`'s permission and both enum keywords were found stranded in informative prose. This is the same boundary from the other side.

## Changes

- New `scripts/section_scope.py`: `parse_heading`, `is_informative`, `informative_lines`.
- `extract_rules.py` rejects a marker inside an informative section, naming the file and line.
- `render_spec.py` now calls `is_informative` instead of restating the expression inline, so the renderer and the extractor cannot disagree about what informative means. Same pattern as `rule_scope.sentence_end`.

Deliberately no `in_note=yes`-style escape: a note is a paragraph inside otherwise normative prose, so an author can reasonably mean it, whereas an informative *heading* declares the whole section disclaimed.

## Verified

Planting a rule inside `#ui-generation`:

```
rule extraction FAILED:
  - 09-extensions.md:419: OOLD-EXT-8650 is inside a section marked .informative, which the
    conformance section declares non-normative, so the catalog would state a requirement the
    specification does not. Move the requirement into a normative section.
```

Inheritance resolves correctly across the section tree, including the case a naive implementation gets wrong - a sibling after an informative section reverting to normative:

```
normative    L5 #why-x-oold-ref
INFORMATIVE  L5 #range-generation-targets
normative    L4 #reverse-properties      <- reverts
INFORMATIVE  L4 #ui-generation
INFORMATIVE  L5 #ui-vocabulary           <- inherited
```

`02-introduction.md` resolves informative through the hardcoded id, `06-composition.md` only for `#closing-composed-objects`.

`docs/spec/index.html` is byte-identical, so the renderer refactor changes no output. `make check` 149/149, `spec check OK (53 sections, 70 rules)`, `rule baseline OK`, no drift.