### PR TITLE
ci: validate with oold-python against this working tree

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # full history + tags so render_spec.py can derive the spec version
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
       - uses: astral-sh/setup-uv@v6
-      - run: npm install
-      - run: npm run validate
+      # Validation runs on oold-python. --meta . reads the meta-schemas and the rule
+      # catalogue from THIS checkout, so a rule added in this branch is enforced by the
+      # run that introduces it; a released version could not see it. Node is no longer
+      # installed here: scripts/validate.mjs is frozen as the reference oold-python is
+      # compared against, and is run by that comparison rather than by this workflow.
+      - run: make validate
       # Re-render the spec and fail if the committed docs/spec/index.html is stale
       # (drift guard), then lint its structure. Renderer deps are pinned inline
       # via PEP 723, so `uv run` stays reproducible.

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,16 @@ ZENSICAL := uvx --with pyyaml==6.0.2 zensical@$(ZENSICAL_VERSION)
 # pinned inline in the script (PEP 723), so `uv run` needs no extra flags and the
 # generated HTML stays reproducible (the CI drift guard compares byte-for-byte).
 
-# Node runs only the schema validator. Override when `node` is not on PATH
-# (e.g. WSL with only a Windows install): make validate NODE="/c/.../node.exe"
+# Validation runs on oold-python, the reference implementation this specification is
+# developed against. Pinned so a validator release cannot change what CI means without a
+# commit here. --meta . points it at THIS working tree rather than a released tag, so a
+# rule added in a branch is enforced by the run that introduces it.
+OOLD_VERSION ?= 0.18.0
+OOLD := uv run --with "oold[validation]==$(OOLD_VERSION)" oold
+
+# scripts/validate.mjs is frozen: kept runnable as the reference the Python port is
+# compared against (oold-python's parity suite), but no longer what CI runs. Override
+# when `node` is not on PATH: make validate-reference NODE="/c/.../node.exe"
 NODE ?= node
 
 .PHONY: install
@@ -18,7 +26,12 @@ install: ## Install the Node dependencies (schema validation)
 	@npm install
 
 .PHONY: validate
-validate: ## Validate example schemas + instances (meta-schema, formats, JSON-LD)
+validate: ## Validate example schemas + instances against this working tree's meta-schemas
+	@$(OOLD) validate examples --meta . --offline
+	@$(OOLD) compliance examples/compliance --meta . --offline
+
+.PHONY: validate-reference
+validate-reference: ## Run the frozen JS reference validator (not run by CI)
 	@"$(NODE)" scripts/validate.mjs
 
 .PHONY: spec


### PR DESCRIPTION
Step 4 of the migration: this repository's CI stops running its own JS validator and runs [oold-python](https://github.com/OO-LD/oold-python), the reference implementation the specification is developed against.

## Changes

- `make validate` runs `oold validate examples` and `oold compliance examples/compliance`, both with `--meta .`
- `oold[validation]` is pinned to `0.18.0`, so a validator release cannot change what CI means without a commit here
- `scripts/validate.mjs` is **frozen, not deleted**: still runnable as `make validate-reference`
- Node is no longer installed in the validate job

## Why `--meta .`

Every other meta-schema source oold-python has is a released tag or `refs/heads/main`. Under those, a rule added in a branch is invisible: the checks bound to it skip, each reporting that the version never stated it, and the run passes. **The pull request that introduces a rule would be the one run that cannot enforce it.**

`--meta .` (added in https://github.com/OO-LD/oold-python/pull/132) reads the meta-schemas and `oold-rules.json` from this checkout, so a branch is validated against its own state. Every rule added to the specification this week would otherwise have gone unchecked in its own PR.

## Why validate.mjs stays

It is the target of oold-python's parity suite, which asserts the two implementations reach the same verdicts on the same fixtures. Deleting it would remove that comparison at exactly the moment it becomes load-bearing, since nothing else validates this repository's examples afterwards.

It is also going to `oold-js` rather than being retired, so the comparison becomes a standing cross-implementation conformance check - the kind of test that catches an ambiguity in the specification rather than a bug in one port. https://github.com/OO-LD/oold-python/pull/133 gates it, and should merge with this.

## Verified

`make validate` on this branch:

```
PASS  examples             380 ok, 0 failed, 21 warning(s), across 21 target(s)
PASS  examples/compliance   71 ok, 0 failed,  1 warning(s), across 53 target(s)
```

`make check` exits 0 end to end. The reference agrees: `make validate-reference` reports 149/149 with its one known warning.

`coverage.rules` reports against `[local]`, confirming it read this tree rather than a release.