### PR TITLE
docs(scripts): state invariants in comments, not prior behaviour

### DIFF
--- a/scripts/check_spec.py
+++ b/scripts/check_spec.py
@@ -93,9 +93,8 @@ if os.path.exists(RULES_FILE):
         rules = json.load(handle).get("rules", [])
 
 # The keywords extraction recognises and the levels the catalog schema admits are two lists of
-# the same thing, written in two files. When they drift, the failure lands nowhere near the
-# cause: extraction succeeds, and the catalog it wrote then fails its own schema. That is what
-# happened when NOT RECOMMENDED was added to the extractor alone.
+# the same thing, written in two files. Checked here because drift between them surfaces nowhere
+# near its cause: extraction succeeds, and the catalog it just wrote then fails its own schema.
 RULES_SCHEMA_FILE = os.path.join(ROOT, "meta", "oold-rules.schema.json")
 if os.path.exists(RULES_SCHEMA_FILE):
     from extract_rules import RFC2119_LEVELS as recognised  # noqa: E402

--- a/scripts/extract_rules.py
+++ b/scripts/extract_rules.py
@@ -137,9 +137,9 @@ def paragraph_bounds(lines: list[str], index: int) -> tuple[int, int]:
     """The prose block containing line `index`.
 
     This feeds `context`: the surrounding prose a rule's sentence was stated in, kept for
-    display. It is not what gets hashed - see rule_scope.sentence_end for the narrower `text`,
-    and for why sentence-level extraction is safe despite the hazards block granularity used to
-    dodge (abbreviations, periods inside code spans).
+    display. It is not what gets hashed - see rule_scope.sentence_end for the narrower `text`, and
+    for how it handles the hazards of cutting prose into sentences (abbreviations, periods inside
+    code spans).
 
     A list item is its own block. Several of the round-trip requirements are bullets in one list,
     and treating the list as a single paragraph would give every one of them the same `context`

--- a/scripts/section_scope.py
+++ b/scripts/section_scope.py
@@ -9,14 +9,15 @@ guidelines, diagrams, examples, and notes in this specification are non-normativ
 express that: the `:::note` / `:::example` blocks that `extract_rules.non_normative_blocks` already
 handles, and a heading marked `.informative`, which is what this module covers.
 
-`scripts/render_spec.py` acted on the second and `scripts/extract_rules.py` did not, so a
-`:rule[...]` placed in an informative section was rendered without RFC 2119 markup and catalogued
-as normative anyway - the catalogue asserting a requirement the specification disclaims on the same
-page. Nothing exploited that, but only because no marker had been written there yet.
+`scripts/render_spec.py` and `scripts/extract_rules.py` both consult :func:`is_informative`, so
+the renderer and the extractor cannot disagree about which sections are disclaimed. They must not:
+the renderer omits RFC 2119 markup in an informative section, and the extractor rejects a
+`:rule[...]` there, so a split reading would let the catalogue assert a requirement the
+specification withdraws on the same page.
 
-The rule itself is small and lives in :func:`is_informative`, so the renderer and the extractor
-cannot disagree about it. Its inheritance is the part worth stating: `informative` propagates to
-every descendant heading, so marking a level-4 section covers the level-5 sections beneath it.
+Inheritance is the part worth stating: `informative` propagates to every descendant heading, so
+marking a level-4 section covers the level-5 sections beneath it, and a sibling at the same level
+starts again from its own markers.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Comments in three scripts explained the defect the code was added for rather than what it now guarantees. Once that code is gone the reference is unreadable, and the history belongs in the commit that made the change.

## Changes

- `scripts/section_scope.py` - states that both the renderer and the extractor read `is_informative`, and why they must agree, instead of recounting that one acted on it and the other did not.
- `scripts/check_spec.py` - states why the two vocabularies are compared here, without naming the keyword that first diverged.
- `scripts/extract_rules.py` - describes how `sentence_end` handles the hazards of sentence splitting, rather than what block granularity avoided.

No behaviour change. `make check` passes, 73 rules, no drift.