### PR TITLE
fix(scripts): count a scoped @context term only where it is a property

### DIFF
--- a/scripts/schema_to_frame.mjs
+++ b/scripts/schema_to_frame.mjs
@@ -64,7 +64,12 @@ export function embeddedProperties(schema) {
   const props = collectProps(schema);
   const structural = Object.keys(props).filter((k) => isEmbed(props[k]));
   const terms = contextTerms(schema["@context"]);
-  const scoped = Object.keys(terms).filter((t) => "@context" in terms[t]);
+  // A scoped term only counts where the schema declares a property of that name. A schema must
+  // reflect every $ref in its @context (OOLD-CMP-b926), including the ones reached from $defs, so
+  // the context carries terms for properties this schema's instances never hold; treating those
+  // as embeds puts a property into the derived frame that no instance can match, and framing then
+  // returns nothing.
+  const scoped = Object.keys(terms).filter((t) => "@context" in terms[t] && t in props);
   return [...new Set([...structural, ...scoped])];
 }
 


### PR DESCRIPTION
`embeddedProperties` in `scripts/schema_to_frame.mjs` took every `@context` term carrying a scoped `@context`, without checking that the schema declares a property of that name.

`OOLD-CMP-b926` requires a schema to reflect every `$ref` in its `@context`, including `$ref`s reached from `$defs`, so the root context carries terms for properties the root object never holds. Such a term made `roundtrip` choose framing over compaction and put an unmatchable property into the derived frame, so framing returned nothing and an unrelated property was reported lost. Full analysis in #149.

Same one-line condition as OO-LD/oold-python#135. Fixed here so the reference implementation stays in parity with `oold-python` and so the fix travels with `validate.mjs` into `oold-js`.

Not exercised by the compliance fixtures, which is why parity did not catch it.

## Verification

`make validate-reference`: 149/149 checks passed, 1 warning (the known rule-coverage warning). Parity from `oold-python` against this branch: 6 passed.
