### PR TITLE
chore: bump the validator pin to oold 0.18.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ZENSICAL := uvx --with pyyaml==6.0.2 zensical@$(ZENSICAL_VERSION)
 # developed against. Pinned so a validator release cannot change what CI means without a
 # commit here. --meta . points it at THIS working tree rather than a released tag, so a
 # rule added in a branch is enforced by the run that introduces it.
-OOLD_VERSION ?= 0.18.0
+OOLD_VERSION ?= 0.18.1
 OOLD := uv run --with "oold[validation]==$(OOLD_VERSION)" oold
 
 # scripts/validate.mjs is frozen: kept runnable as the reference the Python port is


### PR DESCRIPTION
0.18.1 carries the fix from #149 (OO-LD/oold-python#135). 0.18.0 derives a frame from every scoped `@context` term, including ones reflected from `$defs`, so a schema carrying such a term fails `roundtrip.generated` and names an unrelated property as lost.

Not reachable from this repo's own examples, so the result here is unchanged - the pin is what anyone running `make validate` gets.

## Verification

`make validate`: `examples` 380 ok / 0 failed, `examples/compliance` 70 ok / 0 failed, identical to 0.18.0.
